### PR TITLE
Fixed #15, addresses expansion panel bug

### DIFF
--- a/pharmd-app/src/components/Basic/ExpansionPanel.js
+++ b/pharmd-app/src/components/Basic/ExpansionPanel.js
@@ -23,13 +23,15 @@ const ExpansionPanelDetails = styled(ExpansionPanelDetailsMaterial)`
   ${tw`flex-col py-0`}
 `;
 
-const ExpansionPanel = ({ SummaryChild, DetailChild, expand }) => {
+const ExpansionPanel = ({ SummaryChild, DetailChild, defaultExpanded, expanded, onChange }) => {
   return (
     <ExpansionPanelC
       tw="w-full"
-      defaultExpanded={expand}
+      defaultExpanded={defaultExpanded}
       square={true}
       elevation={0}
+      expanded={expanded}
+      onChange={onChange}
     >
       <ExpansionPanelSummary>{SummaryChild}</ExpansionPanelSummary>
       <ExpansionPanelDetails>{DetailChild}</ExpansionPanelDetails>

--- a/pharmd-app/src/screens/student/StudentContentGrid.js
+++ b/pharmd-app/src/screens/student/StudentContentGrid.js
@@ -19,10 +19,11 @@ import StudentList from "./StudentList";
 import MuiPaper from "@material-ui/core/Paper";
 import MuiGrid from "@material-ui/core/Grid";
 import { StudentFilter } from "./StudentToolbarFilter";
+import GridCard from "../../components/Basic/GridCard";
 
 // Style Imports
 import tw, { styled } from "twin.macro";
-import GridCard from "../../components/Basic/GridCard";
+
 
 //-------------------------- STYLE --------------------------
 

--- a/pharmd-app/src/screens/student/StudentDrawer.js
+++ b/pharmd-app/src/screens/student/StudentDrawer.js
@@ -77,6 +77,7 @@ transition: ${props =>
  * Returns a Drawer that contains both filters and student expansion panels.
  * - Expansion panels are open if the drawer is open and the state of the expansion panel is true
  * - Expansion panels are closed if the drawer is closed or the state of the expansion panel is false
+ * - Filter and student preview close when side bar is closed, and open when clicked.
  *
  * @param isOpenMatch the boolean representing if the user selected a student
  * @param selected the ID of the student that has been selected by the user

--- a/pharmd-app/src/screens/student/StudentDrawer.js
+++ b/pharmd-app/src/screens/student/StudentDrawer.js
@@ -57,6 +57,9 @@ transition: ${props =>
 `;
 
 /**
+ * Returns a Drawer that contains both filters and student expansion panels.
+ * - Expansion panels are open if the drawer is open and the state of the expansion panel is true
+ * - Expansion panels are closed if the drawer is closed or the state of the expansion panel is false
  *
  * @param isOpenMatch the boolean representing if the user selected a student
  * @param selected
@@ -67,12 +70,15 @@ transition: ${props =>
  * @constructor
  */
 const StudentDrawer = ({ isOpenMatch, selected, handleClose, handleOpen, ...props }) => {
+  // the state of the sidebar retrieved from redux
   const isOpen = useSelector(state => state.studentSidebarOpen);
+  
   // the drawer should be open if the drawer was manually opened or the user clicked on a student in the table
   const isDrawerOpen = isOpen || isOpenMatch;
   const [filtersQuickViewExpanded, setFiltersQuickViewExpanded] = useState(false);
   const [studentQuickViewExpanded, setStudentQuickViewExpanded] = useState(false);
 
+  // onChange functions for when the expansion panel is clicked on:
   const changeFiltersExpansionPanel = () => {
     isOpen ? setFiltersQuickViewExpanded(!filtersQuickViewExpanded) :
       setFiltersQuickViewExpanded(true);

--- a/pharmd-app/src/screens/student/StudentDrawer.js
+++ b/pharmd-app/src/screens/student/StudentDrawer.js
@@ -1,36 +1,51 @@
-import React, { useState, useEffect } from "react";
+/**
+ * Description:
+ * This component contains the content within the side panel (filters and student preview)
+ *     and the side panel itself.
+ * TODO:
+ *   - Clicking on a student from the student list no longer opens the side bar and no longer opens the student preview expansion panel within the sidebar.
+ * Date: 02-06-2021
+ */
 
-import DrawerMaterial from "@material-ui/core/Drawer";
-import tw, { styled } from "twin.macro";
-import StudentQuickView from "./StudentQuickView";
+//-------------------------- IMPORTS --------------------------
+
+// Function Imports
+import React, { useState, useEffect } from "react";
+import { useListController } from "react-admin";
 import { useSelector } from "react-redux";
-import ExpansionPanel from "../../components/Basic/ExpansionPanel";
-import NavItemSecondary from "../../components/Nav/NavItemSecondary";
-import VerticalSplitIcon from "../../assets/icons/verticalSplit.svg";
-import FilterIcon from "../../assets/icons/filter.svg";
-import PersonIcon from "../../assets/icons/person.svg";
-import Icon from "../../components/Basic/Icon";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { Route, MemoryRouter } from "react-router";
 import { Link as RouterLink } from "react-router-dom";
-import { useListController } from "react-admin";
-import StudentDrawerFilter from "./StudentDrawerFilter";
-// const LinkRouter = props => <Link {...props} component={RouterLink} />;
 
-const DeatilsButton = styled.button`
-  cursor: pointer;
-  color: white;
-  border: none;
-  background-color: #4573ee;
-  margin: 20px 65px 10px 65px;
-  padding: 13px 15px;
-  border-radius: 8px;
-  font-size: 1.3em;
-`;
+// Component Imports
+import DrawerMaterial from "@material-ui/core/Drawer";
+import ExpansionPanel from "../../components/Basic/ExpansionPanel";
+import FilterIcon from "../../assets/icons/filter.svg";
+import NavItemSecondary from "../../components/Nav/NavItemSecondary";
+import PersonIcon from "../../assets/icons/person.svg";
+import StudentDrawerFilter from "./StudentDrawerFilter";
+import StudentQuickView from "./StudentQuickView";
+import VerticalSplitIcon from "../../assets/icons/verticalSplit.svg";
+
+// Style Imports
+import tw, { styled } from "twin.macro";
+
+//-------------------------- STYLE --------------------------
 
 const ButtonSpan = styled.span`
   width: 100%;
 `;
+
+const DeatilsButton = styled.button`
+  background-color: #4573ee;
+  border: none;
+  border-radius: 8px;
+  color: white;
+  cursor: pointer;
+  font-size: 1.3em;
+  margin: 20px 65px 10px 65px;
+  padding: 13px 15px;
+`;
+
 
 const Drawer = styled(DrawerMaterial)`
 
@@ -56,23 +71,25 @@ transition: ${props =>
   }
 `;
 
+//-------------------------- COMPONENT --------------------------
+
 /**
  * Returns a Drawer that contains both filters and student expansion panels.
  * - Expansion panels are open if the drawer is open and the state of the expansion panel is true
  * - Expansion panels are closed if the drawer is closed or the state of the expansion panel is false
  *
  * @param isOpenMatch the boolean representing if the user selected a student
- * @param selected
+ * @param selected the ID of the student that has been selected by the user
  * @param handleClose
  * @param handleOpen
  * @param props
- * @returns {*}
+ * @returns <Drawer> Component with Expansion Panels
  * @constructor
  */
 const StudentDrawer = ({ isOpenMatch, selected, handleClose, handleOpen, ...props }) => {
   // the state of the sidebar retrieved from redux
   const isOpen = useSelector(state => state.studentSidebarOpen);
-  
+
   // the drawer should be open if the drawer was manually opened or the user clicked on a student in the table
   const isDrawerOpen = isOpen || isOpenMatch;
   const [filtersQuickViewExpanded, setFiltersQuickViewExpanded] = useState(false);

--- a/pharmd-app/src/screens/student/StudentDrawer.js
+++ b/pharmd-app/src/screens/student/StudentDrawer.js
@@ -56,9 +56,32 @@ transition: ${props =>
   }
 `;
 
+/**
+ *
+ * @param isOpenMatch the boolean representing if the user selected a student
+ * @param selected
+ * @param handleClose
+ * @param handleOpen
+ * @param props
+ * @returns {*}
+ * @constructor
+ */
 const StudentDrawer = ({ isOpenMatch, selected, handleClose, handleOpen, ...props }) => {
   const isOpen = useSelector(state => state.studentSidebarOpen);
+  // the drawer should be open if the drawer was manually opened or the user clicked on a student in the table
   const isDrawerOpen = isOpen || isOpenMatch;
+  const [filtersQuickViewExpanded, setFiltersQuickViewExpanded] = useState(false);
+  const [studentQuickViewExpanded, setStudentQuickViewExpanded] = useState(false);
+
+  const changeFiltersExpansionPanel = () => {
+    isOpen ? setFiltersQuickViewExpanded(!filtersQuickViewExpanded) :
+      setFiltersQuickViewExpanded(true);
+  };
+
+  const changeStudentExpansionPanel = () => {
+    isOpen ? setStudentQuickViewExpanded(!studentQuickViewExpanded) :
+      setStudentQuickViewExpanded(true);
+  };
 
   //Avoid route errors
   const quickview = () => {
@@ -97,7 +120,9 @@ const StudentDrawer = ({ isOpenMatch, selected, handleClose, handleOpen, ...prop
           />
         }
         DetailChild={<StudentDrawerFilter {...useListController(props)} />}
-        expand={false}
+        defaultExpanded={isDrawerOpen}
+        expanded={isDrawerOpen && filtersQuickViewExpanded}
+        onChange={changeFiltersExpansionPanel}
       />
       <ExpansionPanel
         SummaryChild={
@@ -113,7 +138,9 @@ const StudentDrawer = ({ isOpenMatch, selected, handleClose, handleOpen, ...prop
           </>
         }
         DetailChild={quickview()}
-        expand={isDrawerOpen}
+        defaultExpanded={isDrawerOpen}
+        expanded={isDrawerOpen && studentQuickViewExpanded}
+        onChange={changeStudentExpansionPanel}
       />
     </Drawer>
   );


### PR DESCRIPTION
We fixed the bug where the expansion panels in the student drawer would stay open when we close the drawer. 

* Added a local state that stores the status filter/student expansion panels
* Made logic for the expansion panels to set their `expansion` attribute via the state based on the student drawer and if they were clicked.
* Added our new file comments to better organize imports/style

Resolves #15 
